### PR TITLE
fix docker file causing install errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN corepack enable
 WORKDIR /app
 
 COPY client/package.json client/pnpm-lock.yaml client/pnpm-workspace.yaml ./client/
+COPY shared/ ./shared/
 RUN cd client && pnpm install --frozen-lockfile
 
 
@@ -17,6 +18,7 @@ RUN corepack enable
 WORKDIR /app
 
 COPY server/package.json server/pnpm-lock.yaml server/pnpm-workspace.yaml ./
+COPY shared/ /shared/
 RUN pnpm install --frozen-lockfile
 
 COPY server/tsconfig.json ./
@@ -34,6 +36,7 @@ RUN corepack enable
 WORKDIR /app
 
 COPY server/package.json server/pnpm-lock.yaml server/pnpm-workspace.yaml ./
+COPY shared/ /shared/
 RUN pnpm install --frozen-lockfile --prod
 
 COPY --from=builder /app/dist ./dist/

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "dev": "pnpm run clean && cp -r static/. build/ && nodemon --watch src --ignore src/generated --ext ts --exec \"node scripts/generate-api.js && pnpm run bundle\"",
     "clean": "rm -rf build",
     "setup": "pnpm run clean && node scripts/generate-api.js && cp -r static/. build/",
-    "bundle": "esbuild src/core/index.ts --bundle --outfile=build/index.js --platform=node --format=iife --external:premierepro",
+    "bundle": "esbuild src/core/index.ts --bundle --outfile=build/index.js --platform=node --format=iife --external:premierepro --external:uxp",
     "generate-api": "node scripts/generate-api.js",
     "prepare-packaging": "rm -rf node_modules && pnpm install --prod && node scripts/prepare-packaging.js",
     "format": "prettier --write src scripts tests",

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -35,7 +35,10 @@ interface OpenAPISpec {
 }
 
 export class MCPServer {
-    private readonly server = new Server({ name: "PremiereRemote", version: "1.0.0" });
+    private readonly server = new Server(
+        { name: "PremiereRemote", version: "1.0.0" },
+        { capabilities: { tools: {} } }
+    );
     private readonly operations = new Map<string, OpenAPIOperation>();
     private readonly app: express.Express;
     private httpServer: ReturnType<typeof this.app.listen> | null = null;


### PR DESCRIPTION
Attempting to install would just error out with the following;
```bash
C:\Users\Tom\AppData\Roaming\Adobe\UXP\Plugins\External\PremiereRemote-uxp>type build.log
--progress is a global compose flag, better use `docker compose --progress xx build ...
 Image premiereremote-uxp-premiere-remote Building
#1 [internal] load local bake definitions
#1 reading from stdin 701B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 1.30kB done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/node:lts-alpine
#3 DONE 1.0s

#4 [internal] load .dockerignore
#4 transferring context: 118B done
#4 DONE 0.0s

#5 [api-gen 1/8] FROM docker.io/library/node:lts-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43
#5 resolve docker.io/library/node:lts-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 0.0s done
#5 CACHED

#6 [internal] load build context
#6 transferring context: 936B done
#6 DONE 0.0s

#7 [api-gen 2/8] RUN corepack enable
#7 DONE 0.4s

#8 [stage-2 2/8] RUN apk add --no-cache tini
#8 ...

#9 [api-gen 3/8] WORKDIR /app
#9 DONE 0.1s

#10 [builder 4/9] COPY server/package.json server/pnpm-lock.yaml server/pnpm-workspace.yaml ./
#10 DONE 0.1s

#11 [api-gen 4/8] COPY client/package.json client/pnpm-lock.yaml client/pnpm-workspace.yaml ./client/
#11 DONE 0.2s

#12 [api-gen 5/8] RUN cd client && pnpm install --frozen-lockfile
#12 0.476 ! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-11.21.0.tgz
#12 ...

#8 [stage-2 2/8] RUN apk add --no-cache tini
#8 1.161 (1/1) Installing tini (0.19.0-r3)
#8 1.172 Executing busybox-1.37.0-r31.trigger
#8 1.178 OK: 10.9 MiB in 19 packages
#8 DONE 1.2s

#13 [stage-2 3/8] RUN corepack enable
#13 DONE 0.4s

#14 [builder 5/9] RUN pnpm install --frozen-lockfile
#14 0.496 ! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-11.21.0.tgz
#14 ...

#15 [stage-2 4/8] WORKDIR /app
#15 DONE 0.1s

#16 [stage-2 5/8] COPY server/package.json server/pnpm-lock.yaml server/pnpm-workspace.yaml ./
#16 DONE 0.1s

#12 [api-gen 5/8] RUN cd client && pnpm install --frozen-lockfile
#12 2.575 ? Verifying lockfile against supply-chain policies (215 entries)...
#12 2.585 Lockfile is up to date, resolution step is skipped
#12 2.744 Packages: +161
#12 2.744 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
#12 3.322 Progress: resolved 0, reused 0, downloaded 1, added 0
#12 3.388 Packages are hard linked from the content-addressable store to the virtual store.
#12 3.388   Content-addressable store is at: /root/.local/share/pnpm/store/v11
#12 3.388   Virtual store is at:             node_modules/.pnpm
#12 4.334 Progress: resolved 0, reused 0, downloaded 153, added 154
#12 5.340 Progress: resolved 0, reused 0, downloaded 158, added 159
#12 5.951 Γ£ô Lockfile passes supply-chain policies (215 entries in 3.3s)
#12 6.009 [ENOENT] ENOENT: no such file or directory, scandir '/app/shared'
#12 6.009
#12 6.009
#12 6.009
#12 ...

#14 [builder 5/9] RUN pnpm install --frozen-lockfile
#14 2.581 ? Verifying lockfile against supply-chain policies (224 entries)...
#14 2.591 Lockfile is up to date, resolution step is skipped
#14 2.711 Progress: resolved 1, reused 0, downloaded 0, added 0
#14 2.799 Packages: +224
#14 2.799 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
#14 3.526 Packages are hard linked from the content-addressable store to the virtual store.
#14 3.526   Content-addressable store is at: /root/.local/share/pnpm/store/v11
#14 3.526   Virtual store is at:             node_modules/.pnpm
#14 3.721 Progress: resolved 224, reused 0, downloaded 101, added 16
#14 4.721 Progress: resolved 224, reused 0, downloaded 222, added 222
#14 5.764 Γ£ô Lockfile passes supply-chain policies (224 entries in 3.1s)
#14 5.769 Progress: resolved 224, reused 0, downloaded 223, added 223
#14 5.848 [ENOENT] ENOENT: no such file or directory, scandir '/shared'
#14 5.848
#14 5.848
#14 5.848
#14 ERROR: process "/bin/sh -c pnpm install --frozen-lockfile" did not complete successfully: exit code: 254

#12 [api-gen 5/8] RUN cd client && pnpm install --frozen-lockfile
#12 ERROR: process "/bin/sh -c cd client && pnpm install --frozen-lockfile" did not complete successfully: exit code: 254

#17 [stage-2 6/8] RUN pnpm install --frozen-lockfile --prod
#17 0.388 ! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-11.21.0.tgz
#17 3.475 ? Verifying lockfile against supply-chain policies (224 entries)...
#17 3.487 Lockfile is up to date, resolution step is skipped
#17 3.648 Progress: resolved 1, reused 0, downloaded 0, added 0
#17 3.747 Packages: +114
#17 3.747 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
#17 4.468 Packages are hard linked from the content-addressable store to the virtual store.
#17 4.468   Content-addressable store is at: /root/.local/share/pnpm/store/v11
#17 4.468   Virtual store is at:             node_modules/.pnpm
#17 4.652 Progress: resolved 114, reused 0, downloaded 111, added 28
#17 CANCELED
------
 > [builder 5/9] RUN pnpm install --frozen-lockfile:
3.526   Content-addressable store is at: /root/.local/share/pnpm/store/v11
3.526   Virtual store is at:             node_modules/.pnpm
3.721 Progress: resolved 224, reused 0, downloaded 101, added 16
4.721 Progress: resolved 224, reused 0, downloaded 222, added 222
5.764 Γ£ô Lockfile passes supply-chain policies (224 entries in 3.1s)
5.769 Progress: resolved 224, reused 0, downloaded 223, added 223
5.848 [ENOENT] ENOENT: no such file or directory, scandir '/shared'
5.848
5.848
5.848
------
------
 > [api-gen 5/8] RUN cd client && pnpm install --frozen-lockfile:
3.388 Packages are hard linked from the content-addressable store to the virtual store.
3.388   Content-addressable store is at: /root/.local/share/pnpm/store/v11
3.388   Virtual store is at:             node_modules/.pnpm
4.334 Progress: resolved 0, reused 0, downloaded 153, added 154
5.340 Progress: resolved 0, reused 0, downloaded 158, added 159
5.951 Γ£ô Lockfile passes supply-chain policies (215 entries in 3.3s)
6.009 [ENOENT] ENOENT: no such file or directory, scandir '/app/shared'
6.009
6.009
6.009
------
Dockerfile:7

--------------------

   5 |

   6 |     COPY client/package.json client/pnpm-lock.yaml client/pnpm-workspace.yaml ./client/

   7 | >>> RUN cd client && pnpm install --frozen-lockfile

   8 |

   9 |

--------------------

failed to solve: process "/bin/sh -c cd client && pnpm install --frozen-lockfile" did not complete successfully: exit code: 254
```

I asked my local robot slop simulator how to fix and eventually lead to ensuring the shared folder is copied at various steps. After doing so installation goes flawlessly. Feel free to adjust if needed, idk how docker works the robot is carrying me

Edit: additionally, fixed the server just immediately crashing, as well as fixed missing `--external:uxp` in the `"bundle"` as without it you can encounter build errors if you try to use `require("uxp")`
ie;
```ts
/**
 * return premiere's version
 * @returns {string} premiere version
 */
export async function getPremVer(): Promise<string> {
    const { host } = require("uxp");
    return host.version;
}
```